### PR TITLE
add clear evaluation results before viewing evaluation administration

### DIFF
--- a/src/features/admin/evaluation-administrations/EvaluationAdministrationsTable.tsx
+++ b/src/features/admin/evaluation-administrations/EvaluationAdministrationsTable.tsx
@@ -5,6 +5,7 @@ import { useAppSelector } from "../../../hooks/useAppSelector"
 import { formatDate } from "../../../utils/formatDate"
 import { Pagination } from "../../../components/pagination/Pagination"
 import { getEvaluationAdministrations } from "../../../redux/slices/evaluationAdministrationsSlice"
+import { setEvaluationResults } from "../../../redux/slices/evaluationResultsSlice"
 
 export const EvaluationAdministrationsTable = () => {
   const navigate = useNavigate()
@@ -29,6 +30,7 @@ export const EvaluationAdministrationsTable = () => {
   }, [searchParams])
 
   const handleViewEvaluation = (id: number) => {
+    appDispatch(setEvaluationResults([]))
     navigate(`/admin/evaluation-administrations/${id}`)
   }
 


### PR DESCRIPTION
Ticket IDs: 
- [View Eval Admin - weird behavior with Employee List #94](https://github.com/nerubia/kh360-react/issues/94)
- [View Evaluation Administration Screen - Extra Blank Record displayed in Employee List#111](https://github.com/nerubia/kh360-react/issues/111)
