### PR TITLE
update email logs display after successful nudge

### DIFF
--- a/src/redux/slices/evaluation-administration-slice.ts
+++ b/src/redux/slices/evaluation-administration-slice.ts
@@ -308,8 +308,17 @@ const evaluationAdministrationSlice = createSlice({
       state.loading_send = Loading.Pending
       state.error = null
     })
-    builder.addCase(sendReminder.fulfilled, (state) => {
+    builder.addCase(sendReminder.fulfilled, (state, action) => {
       state.loading_send = Loading.Fulfilled
+      const index = state.evaluators.findIndex(
+        (evaluator) => evaluator.id === parseInt(action.payload.evaluatorId)
+      )
+      if (index !== -1) {
+        const newEmailLog = action.payload.emailLog
+        if (newEmailLog !== undefined) {
+          state.evaluators[index].email_logs?.push(newEmailLog)
+        }
+      }
       state.error = null
     })
     builder.addCase(sendReminder.rejected, (state, action) => {


### PR DESCRIPTION
Ticket ID: [Eval Progress Screen - is it possible to display updated number of reminders after NUDGE button is clicked? #396](https://github.com/nerubia/kh360-react/issues/396)

BE PR: [update send reminder response to add email log #370](https://github.com/nerubia/kh360-nodejs/pull/370)
