### PR TITLE
react-738-add-message-template-screen-wrong-modal-title

### DIFF
--- a/src/features/admin/email-templates/email-template-form/email-template-form.tsx
+++ b/src/features/admin/email-templates/email-template-form/email-template-form.tsx
@@ -222,7 +222,7 @@ export const EmailTemplateForm = () => {
     return (
       <EmailTemplatesDialog
         open={open}
-        title='Cancel'
+        title='Confirm default'
         description={
           <>
             {defaultTemplate.name} is currently set as the default template for this type. <br />


### PR DESCRIPTION
Ticket ID:
Add Message Template Screen - Default's confirmation modal header display is "Cancel" 
[#783](https://github.com/nerubia/kh360-react/issues/783)