### PR TITLE
remove line break for proj assignment form redirect dialog

### DIFF
--- a/src/features/admin/project-assigments/[id]/edit/edit-project-assignment-table.tsx
+++ b/src/features/admin/project-assigments/[id]/edit/edit-project-assignment-table.tsx
@@ -157,7 +157,6 @@ export const EditProjectAssignmentTable = () => {
           description={
             <>
               Are you sure you want to redirect to view {project?.name}?
-              <br />
               <br /> If you redirect now, your data won&apos;t be saved.
             </>
           }


### PR DESCRIPTION
Ticket ID: [The "Select Project Member Skills" screen will no longer be displayed if the "Skills Used" from the project are empty. #803](https://github.com/nerubia/kh360-react/issues/803#issuecomment-1970421123)
