### PR TITLE
react-870-create-edit-eval-date-range

### DIFF
--- a/src/features/admin/evaluation-administrations/[id]/edit/edit-evaluation-administration-form.tsx
+++ b/src/features/admin/evaluation-administrations/[id]/edit/edit-evaluation-administration-form.tsx
@@ -17,7 +17,7 @@ import {
 import { setAlert } from "@redux/slices/app-slice"
 import { getEvaluationResults } from "@redux/slices/evaluation-results-slice"
 import { DateRangePicker } from "@components/ui/date-range-picker/date-range-picker"
-import { type DateValueType } from "react-tailwindcss-datepicker"
+import { type DateType, type DateValueType } from "react-tailwindcss-datepicker"
 import { EvaluationAdministrationStatus } from "@custom-types/evaluation-administration-type"
 
 const EvaluationAdminDialog = lazy(
@@ -164,6 +164,15 @@ export const EditEvaluationAdministrationForm = () => {
     navigate(`/admin/evaluation-administrations/${id}`)
   }
 
+  const dateLimit = (dateString: null | undefined | DateType) => {
+    if (dateString != null) {
+      const currentDate = new Date(dateString)
+      currentDate.setDate(currentDate.getDate() + 1)
+      return currentDate.toString()
+    }
+    return undefined
+  }
+
   return (
     <>
       {loading === Loading.Pending && <div>Loading...</div>}
@@ -214,7 +223,7 @@ export const EditEvaluationAdministrationForm = () => {
                     }}
                     onChange={(value) => handleChangeDateRange(value, "eval_schedule")}
                     dateLimit={{
-                      start_date: formData.eval_period_start_date,
+                      start_date: dateLimit(formData.eval_period_end_date),
                     }}
                     error={{
                       start_date: validationErrors.eval_schedule_start_date,

--- a/src/features/admin/evaluation-administrations/create/create-evaluation-form.tsx
+++ b/src/features/admin/evaluation-administrations/create/create-evaluation-form.tsx
@@ -14,7 +14,7 @@ import { setSelectedEmployeeIds } from "@redux/slices/evaluation-administration-
 import { setEvaluationResults } from "@redux/slices/evaluation-results-slice"
 import { setAlert } from "@redux/slices/app-slice"
 import { DateRangePicker } from "@components/ui/date-range-picker/date-range-picker"
-import { type DateValueType } from "react-tailwindcss-datepicker"
+import { type DateType, type DateValueType } from "react-tailwindcss-datepicker"
 import { createEvaluationAdministrationSchema } from "@utils/validation/evaluation-administration-schema"
 
 const EvaluationAdminDialog = lazy(
@@ -114,6 +114,15 @@ export const CreateEvaluationForm = () => {
     navigate(`/admin/evaluation-administrations`)
   }
 
+  const dateLimit = (dateString: null | undefined | DateType) => {
+    if (dateString != null) {
+      const currentDate = new Date(dateString)
+      currentDate.setDate(currentDate.getDate() + 1)
+      return currentDate.toString()
+    }
+    return undefined
+  }
+
   return (
     <div className='flex flex-col gap-10'>
       <div className='flex flex-col md:w-1/2 gap-4'>
@@ -152,9 +161,7 @@ export const CreateEvaluationForm = () => {
               endDate: formData.eval_schedule_end_date ?? "",
             }}
             onChange={(value) => handleChangeDateRange(value, "eval_schedule")}
-            dateLimit={{
-              start_date: formData.eval_period_start_date,
-            }}
+            dateLimit={{ start_date: dateLimit(formData.eval_period_end_date) }}
             error={{
               start_date: validationErrors.eval_schedule_start_date,
               end_date: validationErrors.eval_schedule_end_date,

--- a/src/utils/validation/evaluation-administration-schema.ts
+++ b/src/utils/validation/evaluation-administration-schema.ts
@@ -71,7 +71,6 @@ export const createEvaluationAdministrationSchema = object().shape({
     .transform(toDateOrUndefined)
     .test("start-date", "Start schedule must be before end schedule", function (start_date) {
       const end_date = this.parent.eval_schedule_end_date
-
       return new Date(start_date) <= new Date(end_date)
     })
     .test(
@@ -95,6 +94,14 @@ export const createEvaluationAdministrationSchema = object().shape({
         return (
           new Date(start_date) <= new Date(maxDate) && new Date(minDate) <= new Date(start_date)
         )
+      }
+    )
+    .test(
+      "not-in-eval-period",
+      "Evaluation schedule must be later than Evaluation Period",
+      function (start_date) {
+        const evalPeriodEndDate = this.parent.eval_period_end_date
+        return new Date(start_date) > new Date(evalPeriodEndDate)
       }
     ),
   eval_schedule_end_date: string()


### PR DESCRIPTION
Ticket ID:
Create & Edit Evaluation - The evaluation schedule should only select a date after the start and end dates of the evaluation period
[#870](https://github.com/nerubia/kh360-react/issues/870)