### PR TITLE
fix message template state when api returns error

### DIFF
--- a/src/redux/slices/email-template-slice.ts
+++ b/src/redux/slices/email-template-slice.ts
@@ -275,6 +275,7 @@ const emailTemplateSlice = createSlice({
     builder.addCase(getByTemplateType.rejected, (state, action) => {
       state.loading = Loading.Rejected
       state.error = action.payload as string
+      state.emailTemplate = null
     })
     /**
      * List all unique email template types


### PR DESCRIPTION
Ticket ID: [Message Template: Employee User - Able to display message template even no default set in Admin #1047](https://github.com/nerubia/kh360-react/issues/1047)
