### PR TITLE
fix error catching in evaluators list screen

### DIFF
--- a/src/features/admin/evaluation-administrations/[id]/evaluees/[evaluation_result_id]/evaluators/evaluators-list.tsx
+++ b/src/features/admin/evaluation-administrations/[id]/evaluees/[evaluation_result_id]/evaluators/evaluators-list.tsx
@@ -203,7 +203,7 @@ export const EvaluatorsList = () => {
           )
           appDispatch(
             setAlert({
-              description: result.payload.message,
+              description: result.payload,
               variant: "destructive",
             })
           )
@@ -234,7 +234,7 @@ export const EvaluatorsList = () => {
         if (result.type === "evaluationAdministration/generateUpdate/rejected") {
           appDispatch(
             setAlert({
-              description: result.payload.message,
+              description: result.payload,
               variant: "destructive",
             })
           )


### PR DESCRIPTION
Ticket ID: [Edit evaluee screen - email issue #1036](https://github.com/nerubia/kh360-react/issues/1036)

BE PR: [throw error when default email template is not found #599](https://github.com/nerubia/kh360-nodejs/pull/599)