### PR TITLE
Skill Map Form - When saving the form without adding skills, the error validation displays white

### DIFF
--- a/src/features/skill-map-forms/[id]/skill-map-form-table.tsx
+++ b/src/features/skill-map-forms/[id]/skill-map-form-table.tsx
@@ -97,7 +97,7 @@ export const SkillMapFormTable = () => {
           appDispatch(
             setAlert({
               description: result.payload,
-              variant: "desctructive",
+              variant: "destructive",
             })
           )
         }


### PR DESCRIPTION
Ticket ID:
Skill Map Form - When saving the form without adding skills, the error validation displays white
[#1081](https://github.com/nerubia/kh360-react/issues/1081)