### PR TITLE
fix: my evaluations data does not clear when switching accounts

### DIFF
--- a/src/features/auth/login/login-form.tsx
+++ b/src/features/auth/login/login-form.tsx
@@ -10,7 +10,7 @@ import { loginSchema } from "@utils/validation/auth-schema"
 import { Loading } from "@custom-types/loadingType"
 import { type LoginFormData } from "@custom-types/form-data-type"
 import { setCheckedUserSkills, setSelectedUserSkills } from "@redux/slices/user-skills-slice"
-import { setUserSkillMapRatings } from "@redux/slices/user-slice"
+import { clearMyEvaluationAdministrations, setUserSkillMapRatings } from "@redux/slices/user-slice"
 
 export const LoginForm = () => {
   const appDispatch = useAppDispatch()
@@ -23,6 +23,7 @@ export const LoginForm = () => {
   const [validationErrors, setValidationErrors] = useState<Partial<LoginFormData>>({})
 
   useEffect(() => {
+    appDispatch(clearMyEvaluationAdministrations())
     appDispatch(setSelectedUserSkills([]))
     appDispatch(setCheckedUserSkills([]))
     appDispatch(setUserSkillMapRatings([]))

--- a/src/redux/slices/user-slice.ts
+++ b/src/redux/slices/user-slice.ts
@@ -380,6 +380,9 @@ const userSlice = createSlice({
   name: "app",
   initialState,
   reducers: {
+    clearMyEvaluationAdministrations: (state) => {
+      state.my_evaluation_administrations = []
+    },
     updateEvaluationStatusById: (state, action) => {
       const { id, status, comment } = action.payload
 
@@ -772,6 +775,7 @@ const userSlice = createSlice({
 })
 
 export const {
+  clearMyEvaluationAdministrations,
   updateEvaluationStatusById,
   updateTotalEvaluations,
   updateTotalSubmitted,


### PR DESCRIPTION
Ticket ID: [My Evaluations - data from other users is retained when switching to a different user](https://github.com/orgs/nerubia/projects/18/views/2?pane=issue&itemId=66321792)