### PR TITLE
fix: other skill name input validation

### DIFF
--- a/src/utils/validation/other-skill-schema.ts
+++ b/src/utils/validation/other-skill-schema.ts
@@ -2,6 +2,7 @@ import { object, string } from "yup"
 
 export const createOtherSkillSchema = object().shape({
   other_skill_name: string()
+    .trim()
     .required("Name is required")
     .max(255, "Name should not exceed 255 characters."),
 })


### PR DESCRIPTION
Ticket ID: [Skill Map Form - Input space in Name field in Add Other Skills shouldn't be allow to be submitted](https://github.com/orgs/nerubia/projects/18/views/2?pane=issue&itemId=70399773)
