### PR TITLE
React 1374 do not allow duplicate names remove extra spaces on name

### DIFF
--- a/src/features/admin/evaluation-template-contents/evaluation-template-content-form/evaluation-template-content-form.tsx
+++ b/src/features/admin/evaluation-template-contents/evaluation-template-content-form/evaluation-template-content-form.tsx
@@ -65,6 +65,14 @@ export const CreateEvaluationTemplateContentForm = () => {
       await createEvaluationTemplateContentSchema.validate(formData, {
         abortEarly: false,
       })
+      const isNameDuplicate = evaluation_template_contents.some(
+        (item) => item.name?.trim() === formData.name?.trim()
+      )
+
+      if (isNameDuplicate) {
+        setValidationErrors({ name: "Name already exists" })
+        return
+      }
       void appDispatch(setEvaluationTemplateContents([...evaluation_template_contents, formData]))
       setFormData({})
       void appDispatch(showCreateModal(!create_modal_visible))
@@ -84,6 +92,16 @@ export const CreateEvaluationTemplateContentForm = () => {
       await createEvaluationTemplateContentSchema.validate(formData, {
         abortEarly: false,
       })
+
+      const isNameDuplicate = evaluation_template_contents.some(
+        (item) => item.name?.trim() === formData.name?.trim()
+      )
+
+      if (isNameDuplicate) {
+        setValidationErrors({ name: "Name already exists" })
+        return
+      }
+
       const updatedData = evaluation_template_contents.map((content, index) => {
         if (index === selected_content_index) {
           return formData

--- a/src/features/admin/evaluation-templates/create/evaluation-template-form.tsx
+++ b/src/features/admin/evaluation-templates/create/evaluation-template-form.tsx
@@ -21,7 +21,10 @@ import { TemplateClass, TemplateType } from "@custom-types/evaluation-template-t
 import { getAllProjectRoles } from "@redux/slices/project-roles-slice"
 import { getActiveAnswers } from "@redux/slices/answer-slice"
 import { EvaluationTemplateContentsTable } from "@features/admin/evaluation-template-contents/evaluation-template-contents-table"
-import { updateEvaluationTemplate } from "@redux/slices/evaluation-template-slice"
+import {
+  getEvaluationTemplate,
+  updateEvaluationTemplate,
+} from "@redux/slices/evaluation-template-slice"
 import { CustomDialog } from "@components/ui/dialog/custom-dialog"
 import { ToggleSwitch } from "@components/ui/toggle-switch/toggle-switch"
 
@@ -285,7 +288,9 @@ export const CreateEvaluationTemplateForm = () => {
           })
         )
         if (result.type === "evaluationTemplate/updateEvaluationTemplate/rejected") {
-          navigate(`/admin/evaluation-templates/${id}`)
+          if (id !== undefined) {
+            void appDispatch(getEvaluationTemplate(parseInt(id)))
+          }
           appDispatch(
             setAlert({
               description: result.payload,

--- a/src/utils/validation/evaluation-template-content-schema.ts
+++ b/src/utils/validation/evaluation-template-content-schema.ts
@@ -1,7 +1,7 @@
 import { boolean, number, object, string } from "yup"
 
 export const createEvaluationTemplateContentSchema = object().shape({
-  name: string().required("Name is required"),
+  name: string().trim().required("Name is required"),
   description: string().required("Description name is required"),
   category: string().required("Category is required"),
   rate: number()


### PR DESCRIPTION
Ticket ID:
Skill Map Forms - submitted skills are not retrieved in previously/newly added forms with latest end date 
Do not allow on adding with duplicate name and remove extra spaces on name
[#1374](https://github.com/nerubia/kh360-react/issues/1374)